### PR TITLE
feat: add feature flag to run cost optimizer in current aws region only

### DIFF
--- a/deployment/workspaces-cost-optimizer.template
+++ b/deployment/workspaces-cost-optimizer.template
@@ -97,6 +97,13 @@ Parameters:
     Type: Number
     Description: The number of hours a Graphics Pro instance can run in a month before being converted to ALWAYS_ON. Default is 80.
     Default: 80
+  OnlyInCurrentRegion:
+    Type: String
+    Description: Execute the cost optimizer only in the current region the cloudformation stack has been installed
+    Default: "No"
+    AllowedValues:
+    - "Yes"
+    - "No"
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -124,6 +131,7 @@ Metadata:
         - DryRun
         - TestEndOfMonth
         - LogLevel
+        - OnlyInCurrentRegion
     - Label:
         default: Pricing Parameters
       Parameters:
@@ -145,6 +153,8 @@ Metadata:
         default: "AWS Fargate SecurityGroup CIDR Block"
       DryRun:
         default: "Launch in Dry Run Mode"
+      OnlyInCurrentRegion:
+        default: "Execute only in deployed aws region"
       TestEndOfMonth:
         default: "Simulate End of Month Cleanup"
       LogLevel:
@@ -519,6 +529,8 @@ Resources:
               Value: !Ref LogLevel
             - Name: DryRun
               Value: !Ref DryRun
+            - Name: OnlyInCurrentRegion
+              Value: !Ref OnlyInCurrentRegion
             - Name: TestEndOfMonth
               Value: !Ref TestEndOfMonth
             - Name: SendAnonymousData
@@ -745,6 +757,8 @@ Outputs:
     Value: !Ref LogLevel
   DryRun:
     Value: !Ref DryRun
+  OnlyInCurrentRegion:
+    Value: !Ref OnlyInCurrentRegion
   SendAnonymousData:
     Value: !FindInMap [Solution, Data, "SendAnonymousUsageData"]
   SolutionID:

--- a/source/ecs/workspaces_app.py
+++ b/source/ecs/workspaces_app.py
@@ -78,7 +78,8 @@ for param in {'LogLevel',
               'PowerLimit',
               'PowerProLimit',
               'GraphicsLimit',
-              'GraphicsProLimit'
+              'GraphicsProLimit',
+              'OnlyInCurrentRegion'
               }:
     stackParams[param] = os.environ[param]
 
@@ -104,20 +105,23 @@ else:
 my_session = boto3.session.Session()
 my_region = my_session.region_name
 
-if 'gov' in my_region:
-    partition = 'aws-us-gov'
-elif 'cn' in my_region:
-    partition = 'aws-cn'
-else:
-    partition = 'aws'
+if stackParams['OnlyInCurrentRegion'] == 'Yes':
+    wsRegions = [my_region]
+else: 
+    if 'gov' in my_region:
+        partition = 'aws-us-gov'
+    elif 'cn' in my_region:
+        partition = 'aws-cn'
+    else:
+        partition = 'aws'
 
-log.debug("Partition is {}".format(partition))
+    log.debug("Partition is {}".format(partition))
 
-try:
-    wsRegions = boto3.session.Session().get_available_regions('workspaces', partition)
-except Exception as e:
-    log.error("Error getting the regions for the workspaces : {}".format(e))
-    raise
+    try:
+        wsRegions = boto3.session.Session().get_available_regions('workspaces', partition)
+    except Exception as e:
+        log.error("Error getting the regions for the workspaces : {}".format(e))
+        raise
 
 # Iterate over list of AWS Regions
 for wsRegion in wsRegions:


### PR DESCRIPTION
*Issue #, if available:*
In our aws accounts some regions are not available / blocked by SCPs.
An exception occured when the cost optimizer tried to search for aws workspaces in regions and blocked the whole solution from running.

*Description of changes:*
- Added flag to only run the cost optimizer in the region where aws cost optimizer has been deployed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
